### PR TITLE
Disabled the stemmer at lunr build time and search time

### DIFF
--- a/static/js/modules-list.js
+++ b/static/js/modules-list.js
@@ -18,6 +18,8 @@ fetch('/js/lunr/PagesIndex.json')
     .then(index => {
         pagesIndex = index;
         lunrIndex = lunr(function () {
+            this.pipeline.remove(lunr.stemmer)
+            this.searchPipeline.remove(lunr.stemmer)
             this.field("title", {boost: 50});
             this.field("description", {boost: 25});
             this.field("tags", {boost: 5});


### PR DESCRIPTION
Otherwise, search with a trailing wildcard return empty result in case of the whole world search

Ticket: CFE-3856