### PR TITLE
Fixed usage of got / got-cjs

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -85,7 +85,7 @@ module.exports = function (grunt) {
         grunt.log.ok("Index built");
     });
 
-    const got = require('got-cjs')
+    const {got} = require('got-cjs')
     const {extname} = require('path')
     const {createHash} = require('crypto')
     grunt.registerTask("modules-update", async function () {


### PR DESCRIPTION
Without this patch, CI/CD pipeline says got is not a function.
