### PR TITLE
Changed Dockerfile to be explicitly Node 18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine AS build
+FROM node:18-alpine AS build
 ARG GITHUB_USERNAME_TOKEN
 WORKDIR /build-website
 ADD https://github.com/gohugoio/hugo/releases/download/v0.104.3/hugo_0.104.3_Linux-64bit.tar.gz hugo.tar.gz


### PR DESCRIPTION
I had a problem where my node:alpine was an old (cached) version,
and did not work, since the new code requires node 18+.
