### PR TITLE
ENT-10415: Copy to clipboard icon not centered

### DIFF
--- a/themes/cfbs-theme/styles/less/modulePage.less
+++ b/themes/cfbs-theme/styles/less/modulePage.less
@@ -216,7 +216,7 @@
   i.bi {
    position: absolute;
    right: 0;
-   top: 1.9rem;
+   top: 1.5rem;
    font-size: 2.1rem;
    cursor: pointer;
    background: @lightGray;


### PR DESCRIPTION
Ticket: ENT-10415
Changelog: minor css change
![image](https://github.com/cfengine/build-website/assets/23060634/87538119-c130-44b6-a1e1-ace2d8ac67d7)
