### PR TITLE
ENT-11184: styles of ul, li and code blocks improved

### DIFF
--- a/themes/cfbs-theme/static/images/orange-list-icon.svg
+++ b/themes/cfbs-theme/static/images/orange-list-icon.svg
@@ -1,0 +1,3 @@
+<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <circle cx="7" cy="7" r="5" stroke="#F5831F" stroke-width="4"/>
+</svg>

--- a/themes/cfbs-theme/styles/less/base.less
+++ b/themes/cfbs-theme/styles/less/base.less
@@ -249,6 +249,12 @@ pre {
 code, pre {
   word-break: break-all;
 }
+code {
+  background: #F7F7F7;
+  padding: 4px;
+  border-radius: 2px;
+  font-size: 1.4rem;
+}
 
 h1 {
   color: @textColorDarkBlue;

--- a/themes/cfbs-theme/styles/less/modulePage.less
+++ b/themes/cfbs-theme/styles/less/modulePage.less
@@ -247,22 +247,15 @@
    margin-top: 1.6rem;
    margin-bottom: 1.6rem;
   }
-  p, ul {
-   margin: 1.6rem 0
+  p {
+   margin: 1.6rem 0;
   }
   ul {
    list-style: none;
+   margin: 0.6rem 0;
    li {
-    margin-left: 1rem;
-    &::before {
-     content: "\2022";
-     color: @blue-800-light;
-     font-weight: bold;
-     display: inline-block;
-     width: 1rem;
-     margin-left: -1rem;
-     position: absolute;
-    }
+    margin-left: 2rem;
+    list-style-image: url(/images/orange-list-icon.svg);
    }
   }
   a {


### PR DESCRIPTION
Before:
![image](https://github.com/cfengine/build-website/assets/23060634/f74abcd3-c49b-4d4b-b869-a89955397726)
After:
![image](https://github.com/cfengine/build-website/assets/23060634/471b8592-ee15-4939-b646-4289c3c881d2)


Ticket: ENT-11184
Changelog: None