### PR TITLE
ENT-11184: styles for non-inline code blocks

### DIFF
--- a/themes/cfbs-theme/styles/less/base.less
+++ b/themes/cfbs-theme/styles/less/base.less
@@ -255,6 +255,11 @@ code {
   border-radius: 2px;
   font-size: 1.4rem;
 }
+pre code {
+  background: none;
+  padding: 0;
+  border-radius: 0;
+}
 
 h1 {
   color: @textColorDarkBlue;


### PR DESCRIPTION

![image](https://github.com/cfengine/build-website/assets/23060634/192abf51-29ff-4571-a12f-f6be328c0c25)
Fixes an issue mentioned in #143

Ticket: ENT-11184
Changelog: None