### PR TITLE
ENT-12178: replaced disqus with a link to gh discussions

### DIFF
--- a/build.js
+++ b/build.js
@@ -90,7 +90,14 @@ const modulesUpdate = async () => {
       } else {
         content = 'Readme not found';
       }
-
+      const discussionParams = new URLSearchParams({
+        category: 'modules',
+        title: index,
+        body: 'I have a question regarding...'
+      })
+      const discussionSearch = new URLSearchParams({
+        discussions_q: `is:open category:Modules ${index}`
+      })
       // frontmatters
       let frontmatter = {
         title: index,
@@ -112,7 +119,9 @@ const modulesUpdate = async () => {
         commit: module.commit,
         dependencies: module.dependencies || [],
         tags: module.tags || [],
-        layout: 'single'
+        layout: 'single',
+        discussion: `https://github.com/cfengine/core/discussions/new?${discussionParams.toString()}`,
+        discussionSearch: `https://github.com/cfengine/core/discussions/categories/modules?${discussionSearch.toString()}`
       };
 
       if (module.hasOwnProperty('version')) {

--- a/config.toml
+++ b/config.toml
@@ -6,7 +6,6 @@ theme = "cfbs-theme"
 # Number of posts per page
 Paginate = 10
 enableRobotsTXT = true
-disqusShortname = 'cfengine-build'
 syntaxCSS = true
 
 [params.info]

--- a/nginx.conf
+++ b/nginx.conf
@@ -73,8 +73,7 @@ http {
         add_header Strict-Transport-Security "max-age=31536000; includeSubdomains" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header 'Referrer-Policy' 'strict-origin';
-        # 'sha256-ruKmkK0iwJgE/F4xuzLY3V2OuzVOOJISav7NURhCKsM=' hugo discuss template (https://github.com/gohugoio/hugo/blob/master/tpl/tplimpl/embedded/templates/disqus.html)
-        add_header Content-Security-Policy "default-src 'none'; style-src 'self' cdn.jsdelivr.net; connect-src 'self' *.disqus.com *.disquscdn.com *.google-analytics.com; script-src 'self' 'sha256-ruKmkK0iwJgE/F4xuzLY3V2OuzVOOJISav7NURhCKsM=' *.disqus.com *.disquscdn.com *.googletagmanager.com; object-src 'self'; img-src 'self' data: https:; font-src 'self' https:; frame-src 'self' www.google.com www.youtube.com *.disqus.com disqus.com;  manifest-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; upgrade-insecure-requests;";
+        add_header Content-Security-Policy "default-src 'none'; style-src 'self' cdn.jsdelivr.net; connect-src 'self' *.google-analytics.com; script-src 'self' *.googletagmanager.com; object-src 'self'; img-src 'self' data: https:; font-src 'self' https:; frame-src 'self' www.google.com www.youtube.com;  manifest-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'; upgrade-insecure-requests;";
 
         #add_header Feature-Policy "speaker self;fullscreen self;";
         ## Block common exploits

--- a/themes/cfbs-theme/layouts/_default/single.html
+++ b/themes/cfbs-theme/layouts/_default/single.html
@@ -108,7 +108,7 @@
                 <div class="tabs">
                     <div class="active" data-tab="1">Description</div>
                     <div data-tab="2">Dependencies</div>
-                    <div data-tab="3">Comments</div>
+                    <div data-tab="3">Discussion</div>
                 </div>
                 <div class="tabs-content-wrapper">
                     <div class="tabs-content opened" id="tab1">{{ .Content }}</div>
@@ -126,7 +126,10 @@
                         <p>This module has no dependencies</p>
                         {{ end }}
                     </div>
-                    <div class="tabs-content" id="tab3">{{ template "_internal/disqus.html" . }}</div>
+                    <div class="tabs-content" id="tab3">
+                        <a href="{{ .Params.DiscussionSearch }}" target="_blank">Find related thread in GitHub discussions</a> or
+                        <a href="{{ .Params.Discussion }}" target="_blank">Start a new discussion</a>
+                    </div>
                 </div>
         </div>
     </div>


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/91967571-bede-4a93-a156-6325fe8b2f25)
Example: 
[Find related thread in GitHub discussions](https://github.com/cfengine/core/discussions/categories/modules?discussions_q=is%3Aopen+category%3AModules+packages-allowlist-snapshot) or [Start a new discussion](https://github.com/cfengine/core/discussions/new?category=modules&title=packages-allowlist-snapshot&body=I+have+a+question+regarding...)
Ticket: ENT-12178
Changelog: None
Signed-off-by: Mikita Pilinka <mikita.pilinka@northern.tech>