### PR TITLE
Hugo 0.135 added a date format validator which does not like toLocaleString() output

### DIFF
--- a/build.js
+++ b/build.js
@@ -94,7 +94,7 @@ const modulesUpdate = async () => {
       // frontmatters
       let frontmatter = {
         title: index,
-        date: new Date(version.timestamp).toLocaleString(),
+        date: new Date(version.timestamp),
         id: index,
         description: module.description || '',
         author: {


### PR DESCRIPTION
toLocaleString() gives 2024-10-10, <time>

but Hugo wants 2024-10-10T<time> which new Date() gives.

Ticket: ENT-12361
